### PR TITLE
Update workflow to generate _version.py correctly

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -70,4 +70,7 @@ jobs:
         python -m pip install -r requirements-dev.txt
     - name: Test documentation build
       run: |
+        # Install package in development mode to generate _version.py
+        pip install -e .
+        # Build documentation
         sphinx-build -b html docsrc docs -E -d "docsrc/_doctrees"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
       run: |
         # Ensure docs directory exists
         mkdir -p docs
+        # Install package in development mode to generate _version.py
+        pip install -e .
         # Build documentation
         sphinx-build -b html docsrc docs -E -d "docsrc/_doctrees"
         # Create .nojekyll to disable Jekyll processing

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -4,7 +4,18 @@ import sys
 sys.path.insert(0, os.path.abspath("../src/talkgooder"))
 sys.path.insert(0, os.path.abspath(".."))
 
-from _version import __version__ as version  # noqa E402 # type: ignore # won't exist until build
+# Try to get version from setuptools-scm generated file, fallback to dynamic import
+try:
+    from _version import __version__ as version  # noqa E402
+except ImportError:
+    # If _version.py doesn't exist (e.g., in CI), try to get version dynamically
+    try:
+        from setuptools_scm import get_version
+
+        version = get_version(root="..")
+    except ImportError:
+        # Final fallback
+        version = "unknown"
 
 extensions = [
     "sphinx.ext.autodoc",


### PR DESCRIPTION
The docs builder relies upon the _version.py file to infer what version to put into the docs. It was not being generated properly.