### PR TITLE
Chore: Update copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2024 Brian Warner
+Copyright (c) Brian Warner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -26,7 +26,7 @@ extensions = [
 ]
 
 project = "talkGooder"
-copyright = "2024, Brian Warner"
+copyright = "Brian Warner"
 author = "Brian Warner"
 release = version
 

--- a/src/talkgooder/__init__.py
+++ b/src/talkgooder/__init__.py
@@ -4,7 +4,7 @@ talkGooder
 
 `talkgooder` attempts to smooth out grammar, punctuation, and number-related corner cases when formatting text for human consumption.
 
-:copyright: (c) 2024 by Brian Warner
+:copyright: (c) Brian Warner
 :license: MIT, see LICENSE.md for more details.
 """  # noqa: E501
 


### PR DESCRIPTION
Making it less of a chore by removing the year.